### PR TITLE
fix: randomize was rounding and loosing data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1336,7 +1336,7 @@ Victor.prototype.toObject = function () {
 var degrees = 180 / Math.PI;
 
 function random (min, max) {
-    return Math.floor(Math.random() * (max - min + 1) + min);
+    return Math.random() * (max - min) + min;
 }
 
 function radian2degrees (rad) {


### PR DESCRIPTION
Whenever `randomize()` was used on floating numbers Victor objects it would destroy the numbers after the decimal point.

I had an issue when I was using it to generate GPS locations within a given range.